### PR TITLE
Corrected syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ To install ansible-scaleio just clone the repo and see site.yml as a generic pla
 
 Customize the roles and playbooks to your environment, you can use this to either to install ScaleIO or just enable the different modules on the nodes.
 ```
-  ansible-playbooks -i hosts site.yml
+  ansible-playbook -i hosts site.yml
 ```
 
 ## Future
 - Enable the SDC client installation
 - Add other roles
-  - callhome 
+  - callhome
 - Extend to do more special setup with cache
 - Clean up the code
 
@@ -41,10 +41,10 @@ Create a fork of the project into your own reposity. Make all your necessary cha
 
 Licensing
 ---------
-The MIT License (MIT) 
-Copyright (c) [2015], [EMC Corporation)] 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+The MIT License (MIT)
+Copyright (c) [2015], [EMC Corporation)]
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.”
 
 


### PR DESCRIPTION
The ansible-playbook had an “s” at the end of playbook which is
incorrect and was not able to run. This fix removes the “s” at the end
of the command and was tested successfully.