### PR TITLE
update gpgkey version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-ubuntu-trusty:
 	-e "scaleio_gateway_virtual_ip=192.168.33.49" \
 	-e "scaleio_gateway_virtual_interface=eth1" \
 	-e "scaleio_common_file_install_file_location=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/Ubuntu/14.04" \
-	-e "scaleio_sdc_driver_sync_emc_public_gpg_key_src=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/common/RPM-GPG-KEY-ScaleIO_2.0.5014.0" \
+	-e "scaleio_sdc_driver_sync_emc_public_gpg_key_src=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/common/RPM-GPG-KEY-ScaleIO_2.0.6035.0" \
 	site.yml
 
 .PHONY:
@@ -30,7 +30,7 @@ test-centos-7: clean
     	-e "scaleio_gateway_virtual_ip=192.168.33.49" \
     	-e "scaleio_gateway_virtual_interface=enp0s8" \
 	-e "scaleio_common_file_install_file_location=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/RHEL/7" \
-	-e "scaleio_sdc_driver_sync_emc_public_gpg_key_src=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/common/RPM-GPG-KEY-ScaleIO_2.0.5014.0" \
+	-e "scaleio_sdc_driver_sync_emc_public_gpg_key_src=$(SCALEIO_COMMON_FILE_INSTALL_FILE_LOCATION)/2.0/common/RPM-GPG-KEY-ScaleIO_2.0.6035.0" \
 	site.yml
 
 .PHONY:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To install ansible-scaleio just clone the repo and see site.yml as a generic pla
 | `#scaleio_sdc_driver_sync_repo_public_rsa_key_src` | Public ssh rsa key source (if using sftp protocol)|  `''` |
 | `scaleio_sdc_driver_sync_repo_public_rsa_key_dest` | Private ssh rsa key destination |  `'/bin/emc/scaleio/scini_sync/scini_repo_key.pub'` |
 | `scaleio_sdc_driver_sync_module_sigcheck` | Do we check the signature |  `1` |
-| `scaleio_sdc_driver_sync_emc_public_gpg_key_src` | Where is the signature file |  `"{{ scaleio_common_file_install_file_location }}/files/RPM-GPG-KEY-ScaleIO_2.0.5014.0"` |
+| `scaleio_sdc_driver_sync_emc_public_gpg_key_src` | Where is the signature file |  `"{{ scaleio_common_file_install_file_location }}/files/RPM-GPG-KEY-ScaleIO_2.0.6035.0"` |
 | `scaleio_sdc_driver_sync_emc_public_gpg_key_dest` | Where to put the signature file |  `'/bin/emc/scaleio/scini_sync/emc_key.pub'` |
 | `scaleio_sdc_driver_sync_sync_pattern` | Repo sync pattern |  `.*` |
 | `scaleio_sds_number` | Number of SDS to run on the sds's |  `1` |

--- a/group_vars/all
+++ b/group_vars/all
@@ -25,7 +25,7 @@ scaleio_sdc_driver_sync_user_private_rsa_key_dest: '/bin/emc/scaleio/scini_sync/
 #scaleio_sdc_driver_sync_repo_public_rsa_key_src: ''
 scaleio_sdc_driver_sync_repo_public_rsa_key_dest: '/bin/emc/scaleio/scini_sync/scini_repo_key.pub'
 scaleio_sdc_driver_sync_module_sigcheck: 1
-scaleio_sdc_driver_sync_emc_public_gpg_key_src: "{{ scaleio_common_file_install_file_location }}/RPM-GPG-KEY-ScaleIO_2.0.5014.0"
+scaleio_sdc_driver_sync_emc_public_gpg_key_src: "{{ scaleio_common_file_install_file_location }}/RPM-GPG-KEY-ScaleIO_2.0.6035.0"
 scaleio_sdc_driver_sync_emc_public_gpg_key_dest: '/bin/emc/scaleio/scini_sync/emc_key.pub'
 scaleio_sdc_driver_sync_sync_pattern: .*
 

--- a/roles/scaleio-sdc/defaults/main.yml
+++ b/roles/scaleio-sdc/defaults/main.yml
@@ -7,6 +7,6 @@ scaleio_sdc_driver_sync_user_private_rsa_key_dest: '/bin/emc/scaleio/scini_sync/
 #scaleio_sdc_driver_sync_repo_public_rsa_key_src: ''
 scaleio_sdc_driver_sync_repo_public_rsa_key_dest: '/bin/emc/scaleio/scini_sync/scini_repo_key.pub'
 scaleio_sdc_driver_sync_module_sigcheck: 1
-scaleio_sdc_driver_sync_emc_public_gpg_key_src: ../../../files/RPM-GPG-KEY-ScaleIO_2.0.5014.0
+scaleio_sdc_driver_sync_emc_public_gpg_key_src: ../../../files/RPM-GPG-KEY-ScaleIO_2.0.6035.0
 scaleio_sdc_driver_sync_emc_public_gpg_key_dest: '/bin/emc/scaleio/scini_sync/emc_key.pub'
 scaleio_sdc_driver_sync_sync_pattern: .*

--- a/roles/scaleio-sdc/tasks/main.yml
+++ b/roles/scaleio-sdc/tasks/main.yml
@@ -10,7 +10,9 @@
   when: scaleio_sdc_driver_sync_repo_public_rsa_key_src is defined
 
 - name: copy scaleio_sdc_driver_sync_emc_public_gpg_key_src for driver_sync.conf
-  copy: src="{{ scaleio_sdc_driver_sync_emc_public_gpg_key_src }}" dest="{{ scaleio_sdc_driver_sync_emc_public_gpg_key_dest }}" mode="0600" owner="root" group="root"
+  copy: src="{{ item }}" dest="{{ scaleio_sdc_driver_sync_emc_public_gpg_key_dest }}" mode="0600" owner="root" group="root"
+  with_fileglob:
+    - "{{ scaleio_sdc_driver_sync_emc_public_gpg_key_src }}"
   when: scaleio_sdc_driver_sync_emc_public_gpg_key_src is defined
 
 - name: copy driver_sync.conf template in place


### PR DESCRIPTION
latest installer tarball references 6035 rather than 5014

./ScaleIO_2.0.0.1_GPG-RPM-KEY_Download/RPM-GPG-KEY-ScaleIO_2.0.6035.0

perhaps it'd be better to turn this into a glob instead?

