### PR TITLE
find some issue when installing on CentOS

### DIFF
--- a/roles/scaleio-common/tasks/install_scaleio_CentOS.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_CentOS.yml
@@ -7,6 +7,11 @@
     - "{{  scaleio_common_file_install_file_location }}/*{{ file_glob_name }}*"
   when: ansible_distribution == "CentOS"
 
+- name: list the rpm file
+  register: package_file
+  find: paths="/var/tmp/" patterns="*{{ file_glob_name }}*.rpm"
+  when: ansible_distribution == "CentOS"
+
 - name: install package
-  raw: "/var/tmp/package_wrapper.sh rpm -i {{ package_file.files[0].path }}" 
+  raw: "/var/tmp/package_wrapper.sh rpm -i {{ package_file.files[0].path }}"
   when: ansible_distribution == "CentOS"

--- a/roles/scaleio-sds/tasks/main.yml
+++ b/roles/scaleio-sds/tasks/main.yml
@@ -14,7 +14,7 @@
   set_fact: disks="{{ scaleio_sds_disks }}"
 
 - name: login to mdm
-  command: scli --login --mdm_ip {{ scaleio_mdm_ips }} --username admin --password "{{ scaleio_password }}"
+  command: scli --login --mdm_ip {{ scaleio_mdm_ips }} --username admin --password "{{ scaleio_password }}" --approve_certificate
   run_once: true
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
 


### PR DESCRIPTION
find some issue when installing on CentOS
1, in CentOS installing, no regist for "package_file"
2, if Master MDM switched, approve_certificate could help  avoid waiting
for 'y' input