### PR TITLE
Added install_scaleio_SLES.yml to support SLES rpm installs

### DIFF
--- a/roles/scaleio-common/tasks/install_scaleio_SLES.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_SLES.yml
@@ -1,0 +1,17 @@
+# vim:ft=ansible:
+---
+- name: copy files
+  copy: src="{{ item }}" dest="/var/tmp/" mode="0644"
+  register: file
+  with_fileglob:
+    - "{{  scaleio_common_file_install_file_location }}/*{{ file_glob_name }}*"
+  when: ansible_distribution == "SLES"
+
+- name: list the rpm file
+  register: package_file
+  find: paths="/var/tmp/" patterns="*{{ file_glob_name }}*.rpm"
+  when: ansible_distribution == "SLES"
+
+- name: install package
+  raw: "/var/tmp/package_wrapper.sh rpm -i {{ package_file.files[0].path }}"
+  when: ansible_distribution == "SLES"


### PR DESCRIPTION
We needed SLES support for installing and configuring ScaleIO. ScaleIO provides SLES rpms so this could be a useful change to any others who use them. 

The only change necessary was copying the CentOS install task since rpm install follows the same process. 