### PR TITLE
Extending SLES support to entire playbook

### DIFF
--- a/roles/scaleio-common/tasks/install_scaleio_java_SLES.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_java_SLES.yml
@@ -1,0 +1,2 @@
+- name: Install pre-requisite java
+  package: name="java-1_8_0-openjdk-devel" state="present"

--- a/roles/scaleio-common/vars/SLES.yml
+++ b/roles/scaleio-common/vars/SLES.yml
@@ -1,0 +1,3 @@
+scaleio_common_packages:
+        - numactl
+        - libaio

--- a/roles/scaleio-gateway/vars/SLES.yml
+++ b/roles/scaleio-gateway/vars/SLES.yml
@@ -1,0 +1,3 @@
+keepalived_packages:
+  - keepalived
+keepalived_config_file_location: /etc/keepalived

--- a/roles/scaleio-mdm/vars/SLES.yml
+++ b/roles/scaleio-mdm/vars/SLES.yml
@@ -1,0 +1,2 @@
+scaleio_mdm_packages:
+        - python

--- a/uninstall_scaleio.yml
+++ b/uninstall_scaleio.yml
@@ -1,8 +1,8 @@
 - name: uninstall scaleio
   hosts: all
   tasks:
-  - name: install package
-    yum: name="{{ item }}" state="absent"
+  - name: uninstall package
+    package: name="{{ item }}" state="absent"
     with_items:
      - EMC-ScaleIO-lia
      - EMC-ScaleIO-sds
@@ -10,3 +10,5 @@
      - EMC-ScaleIO-callhome
      - EMC-ScaleIO-sdc
      - EMC-ScaleIO-tb
+     - EMC-ScaleIO-gateway
+     - EMC-ScaleIO-gui


### PR DESCRIPTION
**Commits**
Adding SLES var files to suppor installing dependent packages. 
Adding install_scaleio_java_SLES.yml, java package naming convention is slightly different than CentOS. 
Modifying uninstall_scaleio.yml to use package module which modifies package using underlying OS package manager.

**Comments**
SLES 11.3 does not support installation of java8 via package manager therefore it is not possible to install gateway or gui onto a SLES 11.3 system. SLES 11.3 support for the other packages works and is still important because ScaleIO distributes a SLES 11.3 ova in their VMware software download package.

Completed end-to-end testing with SLES 11.3 and 12.1
