### PR TITLE
Enhancements and fixes to support ScaleIO 2.5 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ansible-scaleio
 ===============
 
-# NEED NEW MAINTAINER
-
 ansible-scaleio is a way to manage
 [ScaleIO](http://www.emc.com/storage/scaleio/index.htm "ScaleIO") through
 [Ansible](http://www.ansible.com/home "Ansible").

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,5 +1,5 @@
 scaleio_license:
-scaleio_protection_domain: protection_domain1
+scaleio_protection_domain: domain1
 scaleio_cluster_name: cluster1
 scaleio_storage_pool: pool1
 
@@ -12,17 +12,21 @@ scaleio_storage_pool: pool1
 #   - {fs: 'fs3', sds: 'sio5'}
 #   - {fs: 'fs3', sds: 'sio6'}
 
-scaleio_cluster_mode: "5_node"
+scaleio_cluster_mode: "3_node"
 
 scaleio_interface: eth1
-scaleio_password: Cluster1!
+scaleio_password: Password123
 
 scaleio_common_file_install_file_location: "../files"
 
-scaleio_gateway_admin_password: 'Cluster1!'
+scaleio_gateway_admin_password: 'Password123'
 scaleio_gateway_user_properties_file: '/opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties'
 
-scaleio_lia_token: 'Cluster1!'
+scaleio_gateway_http_port: '80'
+scaleio_gateway_https_port: '443'
+scaleio_gateway_catalina_properties_file: '/opt/emc/scaleio/gateway/conf/catalina.properties'
+
+scaleio_lia_token: 'Scaleio123'
 scaleio_lia_conf_file: '/opt/emc/scaleio/lia/cfg/conf.txt'
 
 scaleio_sdc_driver_sync_repo_address: 'ftp://ftp.emc.com/'
@@ -39,6 +43,6 @@ scaleio_sdc_driver_sync_emc_public_gpg_key_dest: '/bin/emc/scaleio/scini_sync/em
 scaleio_sdc_driver_sync_sync_pattern: .*
 
 scaleio_sds_number: 1
-scaleio_sds_disks: { ansible_available_disks: ['/mnt/scaleio1'] }
+scaleio_sds_disks: { ansible_available_disks: ['/dev/sdb'] }
 
 scaleio_skip_java: false

--- a/hosts-3_node
+++ b/hosts-3_node
@@ -1,27 +1,27 @@
+[scaleio]
+node0 ansible_ssh_host=NODE0 ansible_ssh_port=22 ansible_ssh_pass=PASSWORD
+node1 ansible_ssh_host=NODE1 ansible_ssh_port=22 ansible_ssh_pass=PASSWORD
+node2 ansible_ssh_host=NODE2 ansible_ssh_port=22 ansible_ssh_pass=PASSWORD
+
 [mdm]
 node0
 node1
-node2
 
 [tb]
-node3
-node4
+node2
 
 [sds]
+node0
+node1
 node2
-node3
-node4
 
 [lia]
 node0
 node1
 node2
-node3
-node4
 
 [gateway]
 node2
-node3
 
 [gui]
 node0
@@ -30,6 +30,3 @@ node0
 node0
 node1
 node2
-node3
-node4
-

--- a/hosts-5_node
+++ b/hosts-5_node
@@ -1,24 +1,34 @@
 [mdm]
 node0
 node1
+node2
 
 [tb]
-node2
+node3
+node4
 
 [sds]
-node0
-node1
 node2
+node3
+node4
 
 [lia]
 node0
 node1
 node2
+node3
+node4
 
 [gateway]
 node2
+node3
+
+[gui]
+node0
 
 [sdc]
 node0
 node1
 node2
+node3
+node4

--- a/roles/scaleio-common/tasks/install_scaleio_RedHat.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_RedHat.yml
@@ -1,0 +1,17 @@
+# vim:ft=ansible:
+---
+- name: copy files
+  copy: src="{{ item }}" dest="/var/tmp/" mode="0644"
+  register: file
+  with_fileglob:
+    - "{{  scaleio_common_file_install_file_location }}/*{{ file_glob_name }}*"
+  when: ansible_distribution == "RedHat"
+
+- name: list the rpm file
+  register: package_file
+  find: paths="/var/tmp/" patterns="*{{ file_glob_name }}*.rpm"
+  when: ansible_distribution == "RedHat"
+
+- name: install package
+  raw: "/var/tmp/package_wrapper.sh rpm -i {{ package_file.files[0].path }}"
+  when: ansible_distribution == "RedHat"

--- a/roles/scaleio-common/tasks/install_scaleio_java_RedHat.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_java_RedHat.yml
@@ -1,0 +1,2 @@
+- name: Install pre-requisite java
+  package: name="java-1.8.0-openjdk-devel" state="present"

--- a/roles/scaleio-common/tasks/install_scaleio_java_Ubuntu.yml
+++ b/roles/scaleio-common/tasks/install_scaleio_java_Ubuntu.yml
@@ -1,16 +1,5 @@
----
-- name: Install add-apt-repostory
-  apt: name=software-properties-common state=latest
+- name: Install pre-requisite binutils
+  package: name="binutils" state="present"
 
-- name: Add Oracle Java Repository
-  apt_repository: repo='ppa:webupd8team/java'
-
-- name: Accept Java 8 License
-  debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
-
-- name: Install Oracle Java 8
-  apt: name={{item}} state=latest
-  with_items:
-    - oracle-java8-installer
-    - ca-certificates
-    - oracle-java8-set-default
+- name: Install pre-requisite java
+  package: name="openjdk-8-jdk" state="present"

--- a/roles/scaleio-common/vars/RedHat.yml
+++ b/roles/scaleio-common/vars/RedHat.yml
@@ -1,0 +1,3 @@
+scaleio_common_packages:
+        - numactl
+        - libaio

--- a/roles/scaleio-gateway/tasks/main.yml
+++ b/roles/scaleio-gateway/tasks/main.yml
@@ -8,3 +8,24 @@
 
 - include: install_keepalived.yml
   when: scaleio_gateway_is_redundant == "true"
+
+- name: configure gateway with mdm addresses
+  lineinfile: name="{{ scaleio_gateway_user_properties_file }}"
+              regexp='^mdm.ip.addresses'
+              line="mdm.ip.addresses={{ scaleio_mdm_ips }}"
+
+- name: configure gateway to accept certificates
+  lineinfile: name="{{ scaleio_gateway_user_properties_file }}"
+              regexp='^security.bypass_certificate_check'
+              line="security.bypass_certificate_check=true"
+
+- name: configure gateway http port
+  lineinfile: name="{{ scaleio_gateway_catalina_properties_file }}"
+              regexp='^http.port'
+              line="http.port={{ scaleio_gateway_http_port }}"
+
+- name: configure gateway https port
+  lineinfile: name="{{ scaleio_gateway_catalina_properties_file }}"
+              regexp='^ssl.port'
+              line="ssl.port={{ scaleio_gateway_https_port }}"
+

--- a/roles/scaleio-gateway/vars/RedHat.yml
+++ b/roles/scaleio-gateway/vars/RedHat.yml
@@ -1,0 +1,3 @@
+keepalived_packages:
+  - keepalived
+keepalived_config_file_location: /etc/keepalived

--- a/roles/scaleio-mdm/vars/RedHat.yml
+++ b/roles/scaleio-mdm/vars/RedHat.yml
@@ -1,0 +1,3 @@
+scaleio_mdm_packages:
+        - bash-completion
+        - python

--- a/roles/scaleio-sds/tasks/main.yml
+++ b/roles/scaleio-sds/tasks/main.yml
@@ -19,7 +19,7 @@
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
 
 - name: add sds without fault set
-  command: scli --add_sds --mdm_ip {{ scaleio_mdm_ips }} --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }} --storage_pool_name {{ scaleio_storage_pool }} --device_path {{ disks.ansible_available_disks|join(',') }} --sds_name "{{ inventory_hostname}}" --protection_domain_name {{ scaleio_protection_domain }}
+  command: scli --add_sds --mdm_ip {{ scaleio_mdm_ips }} --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }} --storage_pool_name {{ scaleio_storage_pool }} --sds_name "{{ inventory_hostname}}" --protection_domain_name {{ scaleio_protection_domain }}
   register: add_sds
   changed_when: ('already in use' in add_sds.stderr) or (add_sds.rc == 0)
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
@@ -27,10 +27,20 @@
   when: scaleio_fault_sets is not defined
 
 - name: add sds with fault set
-  command: scli --add_sds --mdm_ip {{ scaleio_mdm_ips }} --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }} --storage_pool_name {{ scaleio_storage_pool }} --device_path {{ disks.ansible_available_disks|join(',') }} --sds_name "{{ inventory_hostname}}" --protection_domain_name {{ scaleio_protection_domain }} --fault_set_name {{ item.fs }}
+  command: scli --add_sds --mdm_ip {{ scaleio_mdm_ips }} --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }} --storage_pool_name {{ scaleio_storage_pool }} --sds_name "{{ inventory_hostname}}" --protection_domain_name {{ scaleio_protection_domain }} --fault_set_name {{ item.fs }}
   register: add_sds
   changed_when: ('already in use' in add_sds.stderr) or (add_sds.rc == 0)
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
   ignore_errors: yes
-  when: scaleio_fault_sets is defined and "{{ item.sds }}" == "{{ inventory_hostname }}"
+  when: scaleio_fault_sets is defined
   with_items: scaleio_fault_sets
+
+- name: add sds devices
+  command: scli --add_sds_device --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }} --protection_domain_name {{ scaleio_protection_domain }} --storage_pool_name {{ scaleio_storage_pool }} --device_path {{ disks.ansible_available_disks|join(',') }}
+  retries: 10
+  delay: 5
+  register: add_devices
+  until: add_devices.rc == 0
+  delegate_to: "{{ scaleio_mdm_primary_hostname }}"
+  ignore_errors: yes
+  when: disks.ansible_available_disks|length > 0

--- a/roles/scaleio-tb/tasks/main.yml
+++ b/roles/scaleio-tb/tasks/main.yml
@@ -1,5 +1,11 @@
 - include: ../../scaleio-common/tasks/install_scaleio.yml
 
+- name: Get ScaleIO version
+  shell: scli --version  | sed 's/ (Debug)//g' | sed 's/.* //g' | sed 's/\_.*//g'
+  register: scaleio_version
+  tags: register
+  delegate_to: "{{ scaleio_mdm_primary_hostname }}"
+
 - name: login with new password
   command: scli --login --username admin --password "{{ scaleio_password }}"
   run_once: true
@@ -47,11 +53,27 @@
   run_once: true
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
   register: add_fs
+  when:
+    - scaleio_fault_sets is defined
 
-
-- name: add storage pool
+- name: add storage pool R2
   command: scli --mdm_ip {{ scaleio_mdm_ips }} --add_storage_pool --protection_domain_name {{ scaleio_protection_domain }} --storage_pool_name {{ scaleio_storage_pool }}
+  when: scaleio_version.stdout == "R2"
   run_once: true
   register: storage_pool_add
   delegate_to: "{{ scaleio_mdm_primary_hostname }}"
   changed_when: (storage_pool_add.rc == 7) or (storage_pool_add.rc == 0)
+
+- name: add storage pool R3
+  command: scli --mdm_ip {{ scaleio_mdm_ips }} --add_storage_pool --media_type HDD --protection_domain_name {{ scaleio_protection_domain }} --storage_pool_name {{ scaleio_storage_pool }}
+  when: scaleio_version.stdout == "R3"
+  run_once: true
+  register: storage_pool_add
+  delegate_to: "{{ scaleio_mdm_primary_hostname }}"
+  changed_when: (storage_pool_add.rc == 7) or (storage_pool_add.rc == 0)
+
+- name: enable zero-padding
+  command: scli --modify_zero_padding_policy --protection_domain_name {{ scaleio_protection_domain }} --storage_pool_name {{ scaleio_storage_pool }} --enable_zero_padding
+  run_once: true
+  delegate_to: "{{ scaleio_mdm_primary_hostname }}"
+

--- a/site-no-gui-no-sdc.yml
+++ b/site-no-gui-no-sdc.yml
@@ -26,9 +26,9 @@
     - set_fact: scaleio_tb_secondary_hostname="{{ hostvars[groups['tb'][1]]['inventory_hostname'] }}"
       when: TB_COUNT | int >  1
 
-    - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_secondary_ip }},{{scaleio_mdm_primary_ip}}"
+    - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_primary_ip }},{{scaleio_mdm_secondary_ip}}"
       when: MDM_COUNT | int == 2
-    - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_secondary_ip }},{{scaleio_mdm_primary_ip}},{{scaleio_mdm_tertiary_ip}}"
+    - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_primary_ip }},{{scaleio_mdm_secondary_ip}},{{scaleio_mdm_tertiary_ip}}"
       when: MDM_COUNT | int > 2
 
     - set_fact: scaleio_gateway_primary_ip='{{ hostvars[groups['gateway'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}'
@@ -70,9 +70,3 @@
   roles:
     - scaleio-lia
   tags: scaleio-lia
-
-- hosts: sdc
-  name: "Install and configure ScaleIO SDC"
-  roles:
-    - scaleio-sdc
-  tags: scaleio-sdc

--- a/site.yml
+++ b/site.yml
@@ -3,33 +3,37 @@
 - hosts: all
   name: "set up facts"
   tags: always
+  vars:
+    MDM_COUNT: "{{ groups['mdm'] | length }}"
+    TB_COUNT: "{{ groups['tb'] | length }}"
+    GW_COUNT: "{{ groups['gateway'] | length }}"
   tasks:
     - set_fact: scaleio_mdm_primary_ip="{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
     - set_fact: scaleio_mdm_primary_hostname="{{ hostvars[groups['mdm'][0]]['inventory_hostname'] }}"
     - set_fact: scaleio_mdm_secondary_ip="{{ hostvars[groups['mdm'][1]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
     - set_fact: scaleio_mdm_secondary_hostname="{{ hostvars[groups['mdm'][1]]['inventory_hostname'] }}"
     - set_fact: scaleio_mdm_tertiary_ip="{{ hostvars[groups['mdm'][2]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-      when: hostvars[groups['mdm'][2]] is defined
+      when: MDM_COUNT | int > 2
 
     - set_fact: scaleio_mdm_tertiary_hostname="{{ hostvars[groups['mdm'][2]]['inventory_hostname'] }}"
-      when: hostvars[groups['mdm'][2]] is defined
+      when: MDM_COUNT | int > 2
 
     - set_fact: scaleio_tb_primary_ip="{{ hostvars[groups['tb'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
     - set_fact: scaleio_tb_primary_hostname="{{ hostvars[groups['tb'][0]]['inventory_hostname'] }}"
     - set_fact: scaleio_tb_secondary_ip="{{ hostvars[groups['tb'][1]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-      when: hostvars[groups['tb'][1]] is defined
+      when: TB_COUNT | int >  1
 
     - set_fact: scaleio_tb_secondary_hostname="{{ hostvars[groups['tb'][1]]['inventory_hostname'] }}"
-      when: hostvars[groups['tb'][1]] is defined
+      when: TB_COUNT | int >  1
 
     - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_secondary_ip }},{{scaleio_mdm_primary_ip}}"
-      when: scaleio_mdm_tertiary_ip is not defined
+      when: MDM_COUNT | int == 2
     - set_fact: scaleio_mdm_ips="{{ scaleio_mdm_secondary_ip }},{{scaleio_mdm_primary_ip}},{{scaleio_mdm_tertiary_ip}}"
-      when: scaleio_mdm_tertiary_ip is defined
+      when: MDM_COUNT | int > 2
 
     - set_fact: scaleio_gateway_primary_ip='{{ hostvars[groups['gateway'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}'
     - set_fact: scaleio_gateway_secondary_ip='{{ hostvars[groups['gateway'][1]]['ansible_'+scaleio_interface]['ipv4']['address'] }}'
-      when: hostvars[groups['gateway'][1]] is defined
+      when: GW_COUNT | int > 1
 
 - hosts: all
   name: "Install ScaleIO Common"
@@ -72,7 +76,7 @@
   roles:
     - scaleio-sdc
   tags: scaleio-sdc
-
+  
 - hosts: gui
   name: "Install ScaleIO GUI"
   roles:


### PR DESCRIPTION
- add yaml file to support not installing gui or sdc
- fix to not specify fault sets if not defined
- fixes to modifications of the gateway property file
- support for newer versions of ansible
- adding support for ScaleIO 2.5, 2.6 and above
- fixes to ways in which devices are added to SDS
- use of openjdk on Ubuntu
- addition of binutils package for gateway nodes
- fixing reversal of hosts-3 and hosts-5 configurations
- simplifying format of hosts files
- support for RedHat linux
- set zero padding as default on storage pools